### PR TITLE
Refactor settings to use interface & add extrusion amount reporting

### DIFF
--- a/compilers/SingleMaterialFFFCompiler.cs
+++ b/compilers/SingleMaterialFFFCompiler.cs
@@ -21,7 +21,7 @@ namespace gs
         Action<string> EmitMessageF { get; set; }
 
         void Begin();
-        void AppendPaths(ToolpathSet paths, SingleMaterialFFFSettings pathSettings);
+        void AppendPaths(ToolpathSet paths, ISingleMaterialFFFSettings pathSettings);
         void AppendComment(string comment);
         void End();
     }
@@ -83,11 +83,11 @@ namespace gs
         /// Compile this set of toolpaths and pass to assembler.
         /// Settings are optional, pass null to ignore
         /// </summary>
-		public virtual void AppendPaths(ToolpathSet paths, SingleMaterialFFFSettings pathSettings)
+		public virtual void AppendPaths(ToolpathSet paths, ISingleMaterialFFFSettings pathSettings)
         {
             Assembler.FlushQueues();
 
-            SingleMaterialFFFSettings useSettings = (pathSettings == null) ? Settings : pathSettings;
+            ISingleMaterialFFFSettings useSettings = (pathSettings == null) ? Settings : pathSettings;
 
             CalculateExtrusion calc = new CalculateExtrusion(paths, useSettings);
 			calc.Calculate(Assembler.NozzlePosition, Assembler.ExtruderA, Assembler.InRetract);

--- a/compilers/SingleMaterialFFFCompiler.cs
+++ b/compilers/SingleMaterialFFFCompiler.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using g3;
+using System.Collections.Generic;
 
 namespace gs
 {
-	// [TODO] be able to not hardcode this type?
-	using LinearToolpath = LinearToolpath3<PrintVertex>;
+    // [TODO] be able to not hardcode this type?
+    using LinearToolpath = LinearToolpath3<PrintVertex>;
 
 
     public interface ICNCCompiler
@@ -24,13 +25,14 @@ namespace gs
         void AppendPaths(ToolpathSet paths, ISingleMaterialFFFSettings pathSettings);
         void AppendComment(string comment);
         void End();
+        IEnumerable<string> GenerateTotalExtrusionReport(ISingleMaterialFFFSettings settings);
     }
 
 
 
 	public class SingleMaterialFFFCompiler : ThreeAxisPrinterCompiler
 	{
-		SingleMaterialFFFSettings Settings;
+		ISingleMaterialFFFSettings Settings;
 		GCodeBuilder Builder;
         BaseDepositionAssembler Assembler;
 
@@ -42,7 +44,7 @@ namespace gs
         public virtual Action<string> EmitMessageF { get; set; }
 
 
-        public SingleMaterialFFFCompiler(GCodeBuilder builder, SingleMaterialFFFSettings settings, AssemblerFactoryF AssemblerF )
+        public SingleMaterialFFFCompiler(GCodeBuilder builder, ISingleMaterialFFFSettings settings, AssemblerFactoryF AssemblerF )
 		{
 			Builder = builder;
 			Settings = settings;
@@ -198,5 +200,9 @@ namespace gs
                 EmitMessageF(string.Format(text, args));
         }
 
+        public IEnumerable<string> GenerateTotalExtrusionReport(ISingleMaterialFFFSettings settings)
+        {
+            return Assembler.GenerateTotalExtrusionReport(settings);
+        }
     }
 }

--- a/generators/PrintGeneratorDefaults.cs
+++ b/generators/PrintGeneratorDefaults.cs
@@ -16,11 +16,16 @@ namespace gs
          * Compiler Post-Processors
          */
 
-        public static void AppendPrintTimeStatistics(
+        public static void AppendPrintStatistics(
             ThreeAxisPrinterCompiler compiler, ThreeAxisPrintGenerator printgen)
         {
             compiler.AppendComment("".PadRight(79, '-'));
             foreach (string line in printgen.TotalPrintTimeStatistics.ToStringList()) {
+                compiler.AppendComment(" " + line);
+            }
+            compiler.AppendComment("".PadRight(79, '-'));
+            foreach (string line in printgen.TotalExtrusionReport)
+            {
                 compiler.AppendComment(" " + line);
             }
             compiler.AppendComment("".PadRight(79, '-'));

--- a/generators/SingleMaterialFFFPrintGenerator.cs
+++ b/generators/SingleMaterialFFFPrintGenerator.cs
@@ -23,13 +23,6 @@ namespace gs
             base.Initialize(meshes, slices, settings, compiler);
         }
 
-        public IEnumerable<string> TotalExtrusionReport {
-            get
-            {
-                return Compiler.GenerateTotalExtrusionReport(Settings);
-            }
-        }
-
         protected override GCodeFile extract_result()
         {
             return file_accumulator.File;

--- a/generators/SingleMaterialFFFPrintGenerator.cs
+++ b/generators/SingleMaterialFFFPrintGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace gs
 {
@@ -22,6 +23,12 @@ namespace gs
             base.Initialize(meshes, slices, settings, compiler);
         }
 
+        public IEnumerable<string> TotalExtrusionReport {
+            get
+            {
+                return Compiler.GenerateTotalExtrusionReport(Settings);
+            }
+        }
 
         protected override GCodeFile extract_result()
         {

--- a/generators/ThreeAxisPrintGenerator.cs
+++ b/generators/ThreeAxisPrintGenerator.cs
@@ -64,7 +64,16 @@ namespace gs
 
         public PrintTimeStatistics TotalPrintTimeStatistics { get; private set; } = new PrintTimeStatistics();
 
-		/*
+        public IEnumerable<string> TotalExtrusionReport
+        {
+            get
+            {
+                return Compiler.GenerateTotalExtrusionReport(Settings);
+            }
+        }
+
+
+        /*
 		 * Customizable functions you can use to configure/modify slicer behavior
 		 */
 
@@ -111,7 +120,7 @@ namespace gs
         // Called after we have finished print generation, use this to post-process the paths, etc.
         // By default appends a comment block with print time statistics
         public Action<ThreeAxisPrinterCompiler, ThreeAxisPrintGenerator> PostProcessCompilerF 
-            = PrintGeneratorDefaults.AppendPrintTimeStatistics;
+            = PrintGeneratorDefaults.AppendPrintStatistics;
 
         /// <summary>
         /// If this is set, we clip **generated** regions against it (ie generated support)

--- a/generators/ThreeAxisPrintGenerator.cs
+++ b/generators/ThreeAxisPrintGenerator.cs
@@ -8,33 +8,32 @@ using g3;
 namespace gs
 {
 
-    /// <summary>
-    /// PrintLayerData is set of information for a single print layer
-    /// </summary>
-    public class PrintLayerData
-    {
-        public int layer_i;
-        public PlanarSlice Slice;
-        public ISingleMaterialFFFSettings Settings;
+	/// <summary>
+	/// PrintLayerData is set of information for a single print layer
+	/// </summary>
+	public class PrintLayerData
+	{
+		public int layer_i;
+		public PlanarSlice Slice;
+		public SingleMaterialFFFSettings Settings;
 
-        public PrintLayerData PreviousLayer;
+		public PrintLayerData PreviousLayer;
 
-        public ToolpathSetBuilder PathAccum;
-        public IFillPathScheduler2d Scheduler;
+		public ToolpathSetBuilder PathAccum;
+		public IFillPathScheduler2d Scheduler;
 
-        public List<IShellsFillPolygon> ShellFills;
+		public List<IShellsFillPolygon> ShellFills;
         public List<GeneralPolygon2d> SupportAreas;
 
-        public TemporalPathHash Spatial;
+		public TemporalPathHash Spatial;
 
-        public PrintLayerData(int layer_i, PlanarSlice slice, ISingleMaterialFFFSettings settings)
-        {
-            this.layer_i = layer_i;
-            Slice = slice;
-            Settings = settings;
-            Spatial = new TemporalPathHash();
-        }
-    }
+		public PrintLayerData(int layer_i, PlanarSlice slice, SingleMaterialFFFSettings settings) {
+			this.layer_i = layer_i;
+			Slice = slice;
+			Settings = settings;
+			Spatial = new TemporalPathHash();
+		}
+	}
 
 
 
@@ -82,13 +81,13 @@ namespace gs
 
 
         // Replace this if you want to customize PrintLayerData type
-        public Func<int, PlanarSlice, ISingleMaterialFFFSettings, PrintLayerData> PrintLayerDataFactoryF;
+        public Func<int, PlanarSlice, SingleMaterialFFFSettings, PrintLayerData> PrintLayerDataFactoryF;
 
-        // Replace this to use a different path builder
-        public Func<PrintLayerData, ToolpathSetBuilder> PathBuilderFactoryF;
+		// Replace this to use a different path builder
+		public Func<PrintLayerData, ToolpathSetBuilder> PathBuilderFactoryF;
 
-        // Replace this to use a different scheduler
-        public Func<PrintLayerData, IFillPathScheduler2d> SchedulerFactoryF;
+		// Replace this to use a different scheduler
+		public Func<PrintLayerData, IFillPathScheduler2d> SchedulerFactoryF;
 
         // Replace this to use a different shell selector
         public Func<PrintLayerData, ILayerShellsSelector> ShellSelectorFactoryF;
@@ -97,9 +96,9 @@ namespace gs
         // implement progress bar, etc
         public Action<PrintLayerData> BeginLayerF;
 
-        // This is called before we process each shell. The Tag is transferred
-        // from the associated region in the PlanarSlice, if it had one, otherwise it is int.MaxValue
-        public Action<IFillPolygon, int> BeginShellF;
+		// This is called before we process each shell. The Tag is transferred
+		// from the associated region in the PlanarSlice, if it had one, otherwise it is int.MaxValue
+		public Action<IFillPolygon, int> BeginShellF;
 
         // called at the end of each layer, before we compile the paths
         public ILayerPathsPostProcessor LayerPostProcessor;
@@ -142,37 +141,37 @@ namespace gs
                                SingleMaterialFFFSettings settings,
                                ThreeAxisPrinterCompiler compiler)
         {
-
+			
             PrintMeshes = meshes;
             Slices = slices;
             Settings = settings;
             Compiler = compiler;
 
 
-            // set defaults for configurable functions
+			// set defaults for configurable functions
 
-            PrintLayerDataFactoryF = (layer_i, slice, settingsArg) => {
-                return new PrintLayerData(layer_i, slice, settingsArg);
-            };
+			PrintLayerDataFactoryF = (layer_i, slice, settingsArg) => {
+				return new PrintLayerData(layer_i, slice, settingsArg);
+			};
 
-            PathBuilderFactoryF = (layer_data) => {
-                return new ToolpathSetBuilder();
-            };
+			PathBuilderFactoryF = (layer_data) => {
+				return new ToolpathSetBuilder();
+			};
 
-            SchedulerFactoryF = get_layer_scheduler;
+			SchedulerFactoryF = get_layer_scheduler;
 
             ShellSelectorFactoryF = (layer_data) => {
                 return new NextNearestLayerShellsSelector(layer_data.ShellFills);
             };
 
-            BeginLayerF = (layer_data) => { };
+			BeginLayerF = (layer_data) => { };
 
-            BeginShellF = (shell_fill, tag) => { };
+			BeginShellF = (shell_fill, tag) => { };
 
             LayerPostProcessor = null;
 
             if (PathFilterF == null)
-                PathFilterF = (pline) => { return pline.ArcLength < 3 * Settings.Machine.NozzleDiamMM; };
+				PathFilterF = (pline) => { return pline.ArcLength < 3 * Settings.Machine.NozzleDiamMM; };
 
         }
 
@@ -208,7 +207,7 @@ namespace gs
          *  Internals
          */
 
-
+ 
 
         // tags on slice polygons get transferred to shells
         IntTagSet<IFillPolygon> ShellTags = new IntTagSet<IFillPolygon>();
@@ -221,8 +220,8 @@ namespace gs
         double OverhangAllowanceMM;
         protected virtual double LayerFillAngleF(int layer_i)
         {
-            //return 90;
-            //return (layer_i % 2 == 0) ? 0 : 90;
+			//return 90;
+			//return (layer_i % 2 == 0) ? 0 : 90;
             return (layer_i % 2 == 0) ? -45 : 45;
         }
 
@@ -278,7 +277,7 @@ namespace gs
             precompute_support_areas();
             if (Cancelled()) return;
 
-            PrintLayerData prevLayerData = null;
+			PrintLayerData prevLayerData = null;
 
             // Now generate paths for each layer.
             // This could be parallelized to some extent, but we have to pass per-layer paths
@@ -289,17 +288,17 @@ namespace gs
                 if (Cancelled()) return;
 
                 // allocate new layer data structure
-                ISingleMaterialFFFSettings layerSettings = SettingsFactory(layer_i);
+                SingleMaterialFFFSettings layerSettings = MakeLayerSettings(layer_i);
                 PrintLayerData layerdata = PrintLayerDataFactoryF(layer_i, Slices[layer_i], layerSettings);
-                layerdata.PreviousLayer = prevLayerData;
+				layerdata.PreviousLayer = prevLayerData;
 
-                // create path accumulator
-                ToolpathSetBuilder pathAccum = PathBuilderFactoryF(layerdata);
-                layerdata.PathAccum = pathAccum;
+				// create path accumulator
+				ToolpathSetBuilder pathAccum = PathBuilderFactoryF(layerdata);
+				layerdata.PathAccum = pathAccum;
 
-                // rest of code does not directly access path builder, instead it
-                // sends paths to scheduler.
-                IFillPathScheduler2d layerScheduler = SchedulerFactoryF(layerdata);
+				// rest of code does not directly access path builder, instead it
+				// sends paths to scheduler.
+				IFillPathScheduler2d layerScheduler = SchedulerFactoryF(layerdata);
                 GroupScheduler2d groupScheduler = new GroupScheduler2d(layerScheduler, Compiler.NozzlePosition.xy);
                 //GroupScheduler groupScheduler = new PassThroughGroupScheduler(layerScheduler, Compiler.NozzlePosition.xy);
                 layerdata.Scheduler = groupScheduler;
@@ -307,7 +306,7 @@ namespace gs
                 BeginLayerF(layerdata);
                 Compiler.AppendComment(string.Format("layer {0} - {1}mm", layer_i, Compiler.NozzlePosition.z));
 
-                layerdata.ShellFills = get_layer_shells(layer_i);
+				layerdata.ShellFills = get_layer_shells(layer_i);
 
                 bool is_infill = (layer_i >= Settings.FloorLayers && layer_i < nLayers - Settings.RoofLayers - 1);
 
@@ -343,7 +342,7 @@ namespace gs
                     // schedule shell paths that we pre-computed
                     List<FillCurveSet2d> shells_gen_paths = shells_gen.GetFillCurves();
                     FillCurveSet2d outer_shell = (shells_gen_paths.Count > 0) ? shells_gen_paths[shells_gen_paths.Count - 1] : null;
-                    bool do_outer_last = Settings.OuterShellLast && (shells_gen_paths.Count > 1);
+					bool do_outer_last = Settings.OuterShellLast && (shells_gen_paths.Count > 1);
                     groupScheduler.BeginGroup();
                     if (do_outer_last == false) {
                         groupScheduler.AppendCurveSets(shells_gen_paths);
@@ -365,12 +364,12 @@ namespace gs
                     // [TODO] this can be precomputed now...
                     List<GeneralPolygon2d> infill_regions = new List<GeneralPolygon2d>();
                     if (is_infill)
-                        infill_regions = make_infill_regions(layer_i, solid_fill_regions, roof_cover, floor_cover, out solid_fill_regions);
+						infill_regions = make_infill_regions(layer_i, solid_fill_regions, roof_cover, floor_cover, out solid_fill_regions);
                     bool has_infill = (infill_regions.Count > 0);
 
                     // fill solid regions
                     groupScheduler.BeginGroup();
-                    // [RMS] always call this for now because we may have bridge regions
+					// [RMS] always call this for now because we may have bridge regions
                     // [TODO] we can precompute the bridge region calc we are doing here that is quite expensive...
                     fill_solid_regions(solid_fill_regions, groupScheduler, layerdata, has_infill);
                     groupScheduler.EndGroup();
@@ -401,7 +400,7 @@ namespace gs
                 // discard the group scheduler
                 layerdata.Scheduler = groupScheduler.TargetScheduler;
 
-                // last chance to post-process paths for this layer before they are baked in
+				// last chance to post-process paths for this layer before they are baked in
                 if (Cancelled()) return;
                 if ( LayerPostProcessor != null )
                     LayerPostProcessor.Process(layerdata, pathAccum.Paths);
@@ -496,11 +495,11 @@ namespace gs
                 InsetFromInputPolygon = false,
                 PathSpacing = Settings.SparseLinearInfillStepX * Settings.SolidFillPathSpacingMM(),
                 ToolWidth = Settings.Machine.NozzleDiamMM,
-                AngleDeg = LayerFillAngleF(layer_data.layer_i)
+				AngleDeg = LayerFillAngleF(layer_data.layer_i)
             };
             infill_gen.Compute();
 
-            scheduler.AppendCurveSets(infill_gen.GetFillCurves());
+			scheduler.AppendCurveSets(infill_gen.GetFillCurves());
         }
 
 
@@ -522,15 +521,15 @@ namespace gs
         /// </summary>
 		protected virtual void fill_support_region(GeneralPolygon2d support_poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
         {
-            AxisAlignedBox2d bounds = support_poly.Bounds;
+			AxisAlignedBox2d bounds = support_poly.Bounds;
 
-            // settings may require a shell. However if support region
-            // is very small, we will also use nested shells because infill
-            // poly will likely be empty. In this case we nudge up the spacing
-            // so that they are more loosely bonded
+			// settings may require a shell. However if support region
+			// is very small, we will also use nested shells because infill
+			// poly will likely be empty. In this case we nudge up the spacing
+			// so that they are more loosely bonded
             // [TODO] we should only do this if we are directly below model. Otherwise this
             // branch is hit on any thin tube supports, that we could be printing empty
-            int nShells = (Settings.EnableSupportShell) ? 1 : 0;
+			int nShells = (Settings.EnableSupportShell) ? 1 : 0;
             double support_spacing = Settings.SupportSpacingStepX * Settings.Machine.NozzleDiamMM;
             double shell_spacing = Settings.Machine.NozzleDiamMM;
 			if (bounds.MaxDim < support_spacing) {
@@ -542,16 +541,16 @@ namespace gs
 
 			if (nShells > 0) {
                 ShellsFillPolygon shells_gen = new ShellsFillPolygon(support_poly);
-                shells_gen.PathSpacing = shell_spacing;
+				shells_gen.PathSpacing = shell_spacing;
                 shells_gen.ToolWidth = Settings.Machine.NozzleDiamMM;
-                shells_gen.Layers = nShells;
+				shells_gen.Layers = nShells;
                 shells_gen.FilterSelfOverlaps = false;
-                shells_gen.PreserveInputInsetTopology = true;
+				shells_gen.PreserveInputInsetTopology = true;
                 //shells_gen.FilterSelfOverlaps = true;
                 //shells_gen.PreserveOuterShells = false;
                 //shells_gen.SelfOverlapTolerance = Settings.SelfOverlapToleranceX * Settings.Machine.NozzleDiamMM;
-                shells_gen.DiscardTinyPolygonAreaMM2 = 0.1;
-                shells_gen.DiscardTinyPerimterLengthMM = 0.0;
+				shells_gen.DiscardTinyPolygonAreaMM2 = 0.1;
+				shells_gen.DiscardTinyPerimterLengthMM = 0.0;
                 shells_gen.Compute();
                 List<FillCurveSet2d> shell_fill_curves = shells_gen.GetFillCurves();
                 foreach (var fillpath in shell_fill_curves)
@@ -565,12 +564,12 @@ namespace gs
                     infill_polys = ClipperUtil.MiterOffset(inner_shells, offset);
                 }
 
-            }
+            } 
 
             foreach ( var poly in infill_polys ) {
                 SupportLinesFillPolygon infill_gen = new SupportLinesFillPolygon(poly) {
                     InsetFromInputPolygon = (Settings.EnableSupportShell == false),
-                    PathSpacing = support_spacing,
+					PathSpacing = support_spacing,
                     ToolWidth = Settings.Machine.NozzleDiamMM,
                     AngleDeg = 0,
                 };
@@ -603,8 +602,8 @@ namespace gs
                     // bridge works better if there is a 'landing pad' on either side, so we
                     // expand and then clip with the solid regions, to get actual bridge fill region.
 
-                    double path_width = Settings.Machine.NozzleDiamMM;
-                    double shells_width = Settings.Shells * path_width;
+					double path_width = Settings.Machine.NozzleDiamMM;
+					double shells_width = Settings.Shells * path_width;
                     //bridge_regions = ClipperUtil.MiterOffset(bridge_regions, shells_width, filter_area);
                     bridge_regions = ClipperUtil.SeparateMiterOffsets(bridge_regions, shells_width, filter_area);
                     bridge_regions = ClipperUtil.Intersection(bridge_regions, solid_regions, filter_area);
@@ -620,10 +619,10 @@ namespace gs
                         solid_regions = CurveUtils2.FilterDegenerate(solid_regions, filter_area);     // [RMS] do we need to do this?
 
                         foreach (var bridge_poly in bridge_regions)
-                            fill_bridge_region(bridge_poly, scheduler, layer_data);
-                    }
-                }
-            }
+							fill_bridge_region(bridge_poly, scheduler, layer_data);
+					}
+				}
+			}
 
             foreach (GeneralPolygon2d solid_poly in solid_regions)
                 fill_solid_region(layer_data, solid_poly, scheduler, bIsInfillAdjacent);
@@ -638,8 +637,8 @@ namespace gs
         /// to sparse infill area - when the extruder zigs, most of the time there is nothing
         /// for the filament to attach to, so it pulls back. ugly!)
         /// </summary>
-        protected virtual void fill_solid_region(PrintLayerData layer_data,
-                                                 GeneralPolygon2d solid_poly,
+        protected virtual void fill_solid_region(PrintLayerData layer_data, 
+		                                         GeneralPolygon2d solid_poly, 
                                                  IFillPathScheduler2d scheduler,
                                                  bool bIsInfillAdjacent = false )
         {
@@ -685,32 +684,32 @@ namespace gs
 
                 solid_gen.Compute();
 
-                scheduler.AppendCurveSets(solid_gen.GetFillCurves());
+				scheduler.AppendCurveSets(solid_gen.GetFillCurves());
             }
         }
 
 
 
 
-        /// <summary>
-        /// Fill a bridge region. Goal is to use shortest paths possible.
-        /// So, instead of just using fixed angle, we fit bounding box and
-        /// use the shorter axis. 
-        /// </summary>
-        protected virtual void fill_bridge_region(GeneralPolygon2d poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
-        {
-            double spacing = Settings.BridgeFillPathSpacingMM();
+		/// <summary>
+		/// Fill a bridge region. Goal is to use shortest paths possible.
+		/// So, instead of just using fixed angle, we fit bounding box and
+		/// use the shorter axis. 
+		/// </summary>
+		protected virtual void fill_bridge_region(GeneralPolygon2d poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
+		{
+			double spacing = Settings.BridgeFillPathSpacingMM();
 
-            // fit bbox to try to find fill angle that has shortest spans
-            Box2d box = poly.Outer.MinimalBoundingBox(0.00001);
-            Vector2d axis = (box.Extent.x > box.Extent.y) ? box.AxisY : box.AxisX;
-            double angle = Math.Atan2(axis.y, axis.x) * MathUtil.Rad2Deg;
+			// fit bbox to try to find fill angle that has shortest spans
+			Box2d box = poly.Outer.MinimalBoundingBox(0.00001);
+			Vector2d axis = (box.Extent.x > box.Extent.y) ? box.AxisY : box.AxisX;
+			double angle = Math.Atan2(axis.y, axis.x) * MathUtil.Rad2Deg;
 
-            // [RMS] should we do something like this?
-            //if (Settings.SolidFillBorderOverlapX > 0) {
-            //	double offset = Settings.Machine.NozzleDiamMM * Settings.SolidFillBorderOverlapX;
-            //	fillPolys = ClipperUtil.MiterOffset(fillPolys, offset);
-            //}
+			// [RMS] should we do something like this?
+			//if (Settings.SolidFillBorderOverlapX > 0) {
+			//	double offset = Settings.Machine.NozzleDiamMM * Settings.SolidFillBorderOverlapX;
+			//	fillPolys = ClipperUtil.MiterOffset(fillPolys, offset);
+			//}
 
 			BridgeLinesFillPolygon fill_gen = new BridgeLinesFillPolygon(poly) {
                 InsetFromInputPolygon = false,
@@ -732,12 +731,12 @@ namespace gs
         /// Determine the sparse infill and solid fill regions for a layer, given the input regions that
         /// need to be filled, and the roof/floor areas above/below this layer. 
         /// </summary>
-        protected virtual List<GeneralPolygon2d> make_infill_regions(int layer_i,
-                                                             List<GeneralPolygon2d> fillRegions,
-                                                             List<GeneralPolygon2d> roof_cover,
-                                                             List<GeneralPolygon2d> floor_cover,
+        protected virtual List<GeneralPolygon2d> make_infill_regions(int layer_i, 
+		                                                     List<GeneralPolygon2d> fillRegions, 
+                                                             List<GeneralPolygon2d> roof_cover, 
+                                                             List<GeneralPolygon2d> floor_cover, 
                                                              out List<GeneralPolygon2d> solid_regions)
-
+                                                            
         {
             double min_area = Settings.Machine.NozzleDiamMM * Settings.Machine.NozzleDiamMM;
 
@@ -843,7 +842,7 @@ namespace gs
         /// </summary>
 		protected virtual void add_open_paths(PrintLayerData layerdata, IFillPathScheduler2d scheduler)
         {
-            PlanarSlice slice = layerdata.Slice;
+			PlanarSlice slice = layerdata.Slice;
             if (slice.Paths.Count == 0)
                 return;
 
@@ -890,7 +889,7 @@ namespace gs
             //    PlanarSlice slice = Slices[layeri];
             //    LayerShells[layeri] = compute_shells_for_slice(slice);
             //}
-            return LayerShells[layer_i];
+			return LayerShells[layer_i];
         }
 
         /// <summary>
@@ -945,7 +944,7 @@ namespace gs
             shells_gen.Layers = Settings.Shells;
             shells_gen.FilterSelfOverlaps = Settings.ClipSelfOverlaps;
             shells_gen.SelfOverlapTolerance = Settings.SelfOverlapToleranceX * Settings.Machine.NozzleDiamMM;
-            shells_gen.OuterShellLast = Settings.OuterShellLast;
+			shells_gen.OuterShellLast = Settings.OuterShellLast;
 
             shells_gen.Compute();
             return shells_gen;
@@ -1027,19 +1026,19 @@ namespace gs
             return LayerSupportAreas[layer_i];
         }
 
-        // The set of bridge areas for each layer. These are basically the support
-        // areas that we can bridge. So, they are one layer below the model area.
-        protected List<GeneralPolygon2d>[] LayerBridgeAreas;
+		// The set of bridge areas for each layer. These are basically the support
+		// areas that we can bridge. So, they are one layer below the model area.
+		protected List<GeneralPolygon2d>[] LayerBridgeAreas;
 
-        /// <summary>
-        /// return the set of bridgeable support-region polygons for a layer.
-        /// Note that the bridge regions for layer i are at layer i-1 (because
-        /// these are the support areas)
-        /// </summary>
-        protected virtual List<GeneralPolygon2d> get_layer_bridge_area(int layer_i)
-        {
-            return LayerBridgeAreas[layer_i];
-        }
+		/// <summary>
+		/// return the set of bridgeable support-region polygons for a layer.
+		/// Note that the bridge regions for layer i are at layer i-1 (because
+		/// these are the support areas)
+		/// </summary>
+		protected virtual List<GeneralPolygon2d> get_layer_bridge_area(int layer_i)
+		{
+			return LayerBridgeAreas[layer_i];
+		}
 
 
 
@@ -1049,7 +1048,7 @@ namespace gs
         /// </summary>
         protected virtual void precompute_support_areas()
         {
-            generate_bridge_areas();
+			generate_bridge_areas();
 
             if (Settings.GenerateSupport)
                 generate_support_areas();
@@ -1058,28 +1057,28 @@ namespace gs
         }
 
 
-        /// <summary>
+		/// <summary>
         /// Find the unsupported regions in each layer that can be bridged
         /// </summary>
-        protected virtual void generate_bridge_areas()
-        {
-            int nLayers = Slices.Count;
+		protected virtual void generate_bridge_areas()
+		{
+			int nLayers = Slices.Count;
 
-            LayerBridgeAreas = new List<GeneralPolygon2d>[nLayers];
-            if (nLayers <= 1)
-                return;
+			LayerBridgeAreas = new List<GeneralPolygon2d>[nLayers];
+			if (nLayers <= 1)
+				return;
 
-            // [RMS] does this make sense? maybe should be using 0 here?
-            double bridge_tol = Settings.Machine.NozzleDiamMM * 0.5;
+			// [RMS] does this make sense? maybe should be using 0 here?
+			double bridge_tol = Settings.Machine.NozzleDiamMM * 0.5;
             double expand_delta = bridge_tol * 0.1;     // see usage below
             bridge_tol += expand_delta;
-            double min_area = Settings.Machine.NozzleDiamMM;
-            min_area *= min_area;
+			double min_area = Settings.Machine.NozzleDiamMM;
+			min_area *= min_area;
 
-            gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
+			gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
                 if (Cancelled()) return;
                 PlanarSlice slice = Slices[layeri];
-                PlanarSlice next_slice = Slices[layeri + 1];
+				PlanarSlice next_slice = Slices[layeri + 1];
 
                 // To find bridgeable regions, we compute all floating regions in next layer. 
                 // Then we look for polys that are bridgeable, ie thing enough and fully anchored.
@@ -1094,16 +1093,16 @@ namespace gs
                     bridgePolys = ClipperUtil.Difference(next_slice.Solids, expandPolys, min_area);
                     bridgePolys = CurveUtils2.FilterDegenerate(bridgePolys, min_area);
                     bridgePolys = CurveUtils2.Filter(bridgePolys, (p) => {
-                        return layeri > 0 && is_bridgeable(p, layeri, bridge_tol);
-                    });
-                }
+						return layeri > 0 && is_bridgeable(p, layeri, bridge_tol);
+					});
+				}
 
-                LayerBridgeAreas[layeri] = (bridgePolys != null)
-                    ? bridgePolys : new List<GeneralPolygon2d>();
-            });
-            LayerBridgeAreas[nLayers - 1] = new List<GeneralPolygon2d>();
+				LayerBridgeAreas[layeri] = (bridgePolys != null)
+					? bridgePolys : new List<GeneralPolygon2d>();
+			});
+			LayerBridgeAreas[nLayers - 1] = new List<GeneralPolygon2d>();
 
-        }
+		}
 
 
 
@@ -1147,15 +1146,15 @@ namespace gs
             // to ensure overlap. Using a larger value here has the effect of
             // smoothing out the support polygons. However it can also end up
             // merging disjoint regions...
-            double fMergeDownDilate = Settings.Machine.NozzleDiamMM * Settings.SupportRegionJoinTolX;
+			double fMergeDownDilate = Settings.Machine.NozzleDiamMM * Settings.SupportRegionJoinTolX;
 
             // space we leave between support polygons and solids
             // [TODO] do we need to include SupportAreaOffsetX here?
             double fSupportGapInLayer = Settings.SupportSolidSpace;
 
-            // extra offset we add to support polygons, eg to nudge them
-            // in/out depending on shell layers, etc
-            double fSupportOffset = Settings.SupportAreaOffsetX * Settings.Machine.NozzleDiamMM;
+			// extra offset we add to support polygons, eg to nudge them
+			// in/out depending on shell layers, etc
+			double fSupportOffset = Settings.SupportAreaOffsetX * Settings.Machine.NozzleDiamMM;
 
             // we will throw away holes in support regions smaller than these thresholds
 			double DiscardHoleSizeMM = 2*Settings.Machine.NozzleDiamMM;
@@ -1164,36 +1163,36 @@ namespace gs
             // throw away support polygons smaller than this
             double fMinDiameter = Settings.SupportMinDimension;
 
-            // if support poly is further than this from model, we consider
-            // it a min-z-tip and it gets special handling
-            double fSupportMinDist = Settings.Machine.NozzleDiamMM;
+			// if support poly is further than this from model, we consider
+			// it a min-z-tip and it gets special handling
+			double fSupportMinDist = Settings.Machine.NozzleDiamMM;
 
 
 
             int nLayers = Slices.Count;
-            LayerSupportAreas = new List<GeneralPolygon2d>[nLayers];
-            if (nLayers <= 1)
-                return;
+			LayerSupportAreas = new List<GeneralPolygon2d>[nLayers];
+			if (nLayers <= 1)
+				return;
 
 
             bool bEnableInterLayerSmoothing = true;
 
 
-            /*
+			/*
 			 * Step 1: compute absolute support polygon for each layer
 			 */
 
-            // For layer i, compute support region needed to support layer (i+1)
-            // This is the *absolute* support area - no inset for filament width or spacing from model
-            gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
+			// For layer i, compute support region needed to support layer (i+1)
+			// This is the *absolute* support area - no inset for filament width or spacing from model
+			gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
                 if (Cancelled()) return;
                 PlanarSlice slice = Slices[layeri];
-                PlanarSlice next_slice = Slices[layeri + 1];
+				PlanarSlice next_slice = Slices[layeri + 1];
 
-                // expand this layer and subtract from next layer. leftovers are
-                // what needs to be supported on next layer.
-                List<GeneralPolygon2d> expandPolys = ClipperUtil.MiterOffset(slice.Solids, fOverhangAngleDist);
-                List<GeneralPolygon2d> supportPolys = ClipperUtil.Difference(next_slice.Solids, expandPolys);
+				// expand this layer and subtract from next layer. leftovers are
+				// what needs to be supported on next layer.
+				List<GeneralPolygon2d> expandPolys = ClipperUtil.MiterOffset(slice.Solids, fOverhangAngleDist);
+				List<GeneralPolygon2d> supportPolys = ClipperUtil.Difference(next_slice.Solids, expandPolys);
 
                 // subtract regions we are going to bridge
                 List<GeneralPolygon2d> bridgePolys = get_layer_bridge_area(layeri);
@@ -1263,14 +1262,14 @@ namespace gs
 
                         // ok force support
                         filteredPolys.Add(make_support_point_poly(bounds.Center, fMinDiameter));
-                    }
+				    }
                     supportPolys.Clear();
                     supportPolys.AddRange(filteredPolys);
-                }
+                } 
 
-                // add any explicit support points in this layer as circles
-                foreach (Vector2d v in slice.InputSupportPoints)
-                    supportPolys.Add(make_support_point_poly(v));
+				// add any explicit support points in this layer as circles
+				foreach (Vector2d v in slice.InputSupportPoints)
+					supportPolys.Add(make_support_point_poly(v));
 
                 if (PathClipRegions != null)
                     supportPolys = ClipperUtil.Intersection(supportPolys, PathClipRegions);
@@ -1281,7 +1280,7 @@ namespace gs
             LayerSupportAreas[nLayers-1] = new List<GeneralPolygon2d>();
 
 
-            /*
+			/*
 			 * Step 2: sweep support polygons downwards
 			 */
 
@@ -1330,8 +1329,8 @@ namespace gs
                     support_above.Add(copy);
                 }
 
-                // union down
-                List<GeneralPolygon2d> combineSupport = null;
+				// union down
+				List<GeneralPolygon2d> combineSupport = null;
 
                 // [TODO] should discard small interior holes here if they don't intersect layer...
 
@@ -1421,9 +1420,9 @@ namespace gs
         }
 
 
-        /*
+		/*
 		 * Bridging and Support utility functions
-		 */
+		 */ 
 
         /// <summary>
         /// generate support point polygon (eg circle)
@@ -1508,10 +1507,10 @@ namespace gs
         /// </summary>
 		protected virtual IFillPathScheduler2d get_layer_scheduler(PrintLayerData layer_data)
         {
-            SequentialScheduler2d scheduler = new SequentialScheduler2d(layer_data.PathAccum, layer_data.Settings);
+			SequentialScheduler2d scheduler = new SequentialScheduler2d(layer_data.PathAccum, layer_data.Settings);
 
             // be careful on first layer
-            scheduler.SpeedHint = (layer_data.layer_i == CurStartLayer) ?
+			scheduler.SpeedHint = (layer_data.layer_i == CurStartLayer) ?
                 SchedulerSpeedHint.Careful : SchedulerSpeedHint.Rapid;
 
             return scheduler;

--- a/generators/ThreeAxisPrintGenerator.cs
+++ b/generators/ThreeAxisPrintGenerator.cs
@@ -8,32 +8,33 @@ using g3;
 namespace gs
 {
 
-	/// <summary>
-	/// PrintLayerData is set of information for a single print layer
-	/// </summary>
-	public class PrintLayerData
-	{
-		public int layer_i;
-		public PlanarSlice Slice;
-		public SingleMaterialFFFSettings Settings;
+    /// <summary>
+    /// PrintLayerData is set of information for a single print layer
+    /// </summary>
+    public class PrintLayerData
+    {
+        public int layer_i;
+        public PlanarSlice Slice;
+        public ISingleMaterialFFFSettings Settings;
 
-		public PrintLayerData PreviousLayer;
+        public PrintLayerData PreviousLayer;
 
-		public ToolpathSetBuilder PathAccum;
-		public IFillPathScheduler2d Scheduler;
+        public ToolpathSetBuilder PathAccum;
+        public IFillPathScheduler2d Scheduler;
 
-		public List<IShellsFillPolygon> ShellFills;
+        public List<IShellsFillPolygon> ShellFills;
         public List<GeneralPolygon2d> SupportAreas;
 
-		public TemporalPathHash Spatial;
+        public TemporalPathHash Spatial;
 
-		public PrintLayerData(int layer_i, PlanarSlice slice, SingleMaterialFFFSettings settings) {
-			this.layer_i = layer_i;
-			Slice = slice;
-			Settings = settings;
-			Spatial = new TemporalPathHash();
-		}
-	}
+        public PrintLayerData(int layer_i, PlanarSlice slice, ISingleMaterialFFFSettings settings)
+        {
+            this.layer_i = layer_i;
+            Slice = slice;
+            Settings = settings;
+            Spatial = new TemporalPathHash();
+        }
+    }
 
 
 
@@ -48,7 +49,7 @@ namespace gs
         public PrintMeshAssembly PrintMeshes { get; protected set; }
         public PlanarSliceStack Slices { get; protected set; }
         public ThreeAxisPrinterCompiler Compiler { get; protected set; }
-        public SingleMaterialFFFSettings Settings;      // public because you could modify
+        public ISingleMaterialFFFSettings Settings;      // public because you could modify
                                                         // this during process, ie in BeginLayerF
                                                         // to implement per-layer settings
 
@@ -81,13 +82,13 @@ namespace gs
 
 
         // Replace this if you want to customize PrintLayerData type
-        public Func<int, PlanarSlice, SingleMaterialFFFSettings, PrintLayerData> PrintLayerDataFactoryF;
+        public Func<int, PlanarSlice, ISingleMaterialFFFSettings, PrintLayerData> PrintLayerDataFactoryF;
 
-		// Replace this to use a different path builder
-		public Func<PrintLayerData, ToolpathSetBuilder> PathBuilderFactoryF;
+        // Replace this to use a different path builder
+        public Func<PrintLayerData, ToolpathSetBuilder> PathBuilderFactoryF;
 
-		// Replace this to use a different scheduler
-		public Func<PrintLayerData, IFillPathScheduler2d> SchedulerFactoryF;
+        // Replace this to use a different scheduler
+        public Func<PrintLayerData, IFillPathScheduler2d> SchedulerFactoryF;
 
         // Replace this to use a different shell selector
         public Func<PrintLayerData, ILayerShellsSelector> ShellSelectorFactoryF;
@@ -96,9 +97,9 @@ namespace gs
         // implement progress bar, etc
         public Action<PrintLayerData> BeginLayerF;
 
-		// This is called before we process each shell. The Tag is transferred
-		// from the associated region in the PlanarSlice, if it had one, otherwise it is int.MaxValue
-		public Action<IFillPolygon, int> BeginShellF;
+        // This is called before we process each shell. The Tag is transferred
+        // from the associated region in the PlanarSlice, if it had one, otherwise it is int.MaxValue
+        public Action<IFillPolygon, int> BeginShellF;
 
         // called at the end of each layer, before we compile the paths
         public ILayerPathsPostProcessor LayerPostProcessor;
@@ -125,7 +126,7 @@ namespace gs
         {
         }
 
-        public ThreeAxisPrintGenerator(PrintMeshAssembly meshes, 
+        public ThreeAxisPrintGenerator(PrintMeshAssembly meshes,
                                        PlanarSliceStack slices,
                                        SingleMaterialFFFSettings settings,
                                        ThreeAxisPrinterCompiler compiler)
@@ -136,42 +137,42 @@ namespace gs
 
 
 
-        public void Initialize(PrintMeshAssembly meshes, 
+        public void Initialize(PrintMeshAssembly meshes,
                                PlanarSliceStack slices,
                                SingleMaterialFFFSettings settings,
                                ThreeAxisPrinterCompiler compiler)
         {
-			
+
             PrintMeshes = meshes;
             Slices = slices;
             Settings = settings;
             Compiler = compiler;
 
 
-			// set defaults for configurable functions
+            // set defaults for configurable functions
 
-			PrintLayerDataFactoryF = (layer_i, slice, settingsArg) => {
-				return new PrintLayerData(layer_i, slice, settingsArg);
-			};
+            PrintLayerDataFactoryF = (layer_i, slice, settingsArg) => {
+                return new PrintLayerData(layer_i, slice, settingsArg);
+            };
 
-			PathBuilderFactoryF = (layer_data) => {
-				return new ToolpathSetBuilder();
-			};
+            PathBuilderFactoryF = (layer_data) => {
+                return new ToolpathSetBuilder();
+            };
 
-			SchedulerFactoryF = get_layer_scheduler;
+            SchedulerFactoryF = get_layer_scheduler;
 
             ShellSelectorFactoryF = (layer_data) => {
                 return new NextNearestLayerShellsSelector(layer_data.ShellFills);
             };
 
-			BeginLayerF = (layer_data) => { };
+            BeginLayerF = (layer_data) => { };
 
-			BeginShellF = (shell_fill, tag) => { };
+            BeginShellF = (shell_fill, tag) => { };
 
             LayerPostProcessor = null;
 
             if (PathFilterF == null)
-				PathFilterF = (pline) => { return pline.ArcLength < 3 * Settings.Machine.NozzleDiamMM; };
+                PathFilterF = (pline) => { return pline.ArcLength < 3 * Settings.Machine.NozzleDiamMM; };
 
         }
 
@@ -207,7 +208,7 @@ namespace gs
          *  Internals
          */
 
- 
+
 
         // tags on slice polygons get transferred to shells
         IntTagSet<IFillPolygon> ShellTags = new IntTagSet<IFillPolygon>();
@@ -220,8 +221,8 @@ namespace gs
         double OverhangAllowanceMM;
         protected virtual double LayerFillAngleF(int layer_i)
         {
-			//return 90;
-			//return (layer_i % 2 == 0) ? 0 : 90;
+            //return 90;
+            //return (layer_i % 2 == 0) ? 0 : 90;
             return (layer_i % 2 == 0) ? -45 : 45;
         }
 
@@ -250,12 +251,12 @@ namespace gs
             if (AccumulatePathSet == true)
                 AccumulatedPaths = new ToolpathSet();
 
-			// build spatial caches for slice polygons
-			//bool need_slice_spatial = (Settings.GenerateSupport);
-			bool need_slice_spatial = true;  // need this for bridges...
+            // build spatial caches for slice polygons
+            //bool need_slice_spatial = (Settings.GenerateSupport);
+            bool need_slice_spatial = true;  // need this for bridges...
 			if (need_slice_spatial) {
-				Slices.BuildSliceSpatialCaches(true);
-			}
+                Slices.BuildSliceSpatialCaches(true);
+            }
 
             if (Cancelled()) return;
 
@@ -277,7 +278,7 @@ namespace gs
             precompute_support_areas();
             if (Cancelled()) return;
 
-			PrintLayerData prevLayerData = null;
+            PrintLayerData prevLayerData = null;
 
             // Now generate paths for each layer.
             // This could be parallelized to some extent, but we have to pass per-layer paths
@@ -288,17 +289,17 @@ namespace gs
                 if (Cancelled()) return;
 
                 // allocate new layer data structure
-                SingleMaterialFFFSettings layerSettings = MakeLayerSettings(layer_i);
+                ISingleMaterialFFFSettings layerSettings = SettingsFactory(layer_i);
                 PrintLayerData layerdata = PrintLayerDataFactoryF(layer_i, Slices[layer_i], layerSettings);
-				layerdata.PreviousLayer = prevLayerData;
+                layerdata.PreviousLayer = prevLayerData;
 
-				// create path accumulator
-				ToolpathSetBuilder pathAccum = PathBuilderFactoryF(layerdata);
-				layerdata.PathAccum = pathAccum;
+                // create path accumulator
+                ToolpathSetBuilder pathAccum = PathBuilderFactoryF(layerdata);
+                layerdata.PathAccum = pathAccum;
 
-				// rest of code does not directly access path builder, instead it
-				// sends paths to scheduler.
-				IFillPathScheduler2d layerScheduler = SchedulerFactoryF(layerdata);
+                // rest of code does not directly access path builder, instead it
+                // sends paths to scheduler.
+                IFillPathScheduler2d layerScheduler = SchedulerFactoryF(layerdata);
                 GroupScheduler2d groupScheduler = new GroupScheduler2d(layerScheduler, Compiler.NozzlePosition.xy);
                 //GroupScheduler groupScheduler = new PassThroughGroupScheduler(layerScheduler, Compiler.NozzlePosition.xy);
                 layerdata.Scheduler = groupScheduler;
@@ -306,7 +307,7 @@ namespace gs
                 BeginLayerF(layerdata);
                 Compiler.AppendComment(string.Format("layer {0} - {1}mm", layer_i, Compiler.NozzlePosition.z));
 
-				layerdata.ShellFills = get_layer_shells(layer_i);
+                layerdata.ShellFills = get_layer_shells(layer_i);
 
                 bool is_infill = (layer_i >= Settings.FloorLayers && layer_i < nLayers - Settings.RoofLayers - 1);
 
@@ -342,7 +343,7 @@ namespace gs
                     // schedule shell paths that we pre-computed
                     List<FillCurveSet2d> shells_gen_paths = shells_gen.GetFillCurves();
                     FillCurveSet2d outer_shell = (shells_gen_paths.Count > 0) ? shells_gen_paths[shells_gen_paths.Count - 1] : null;
-					bool do_outer_last = Settings.OuterShellLast && (shells_gen_paths.Count > 1);
+                    bool do_outer_last = Settings.OuterShellLast && (shells_gen_paths.Count > 1);
                     groupScheduler.BeginGroup();
                     if (do_outer_last == false) {
                         groupScheduler.AppendCurveSets(shells_gen_paths);
@@ -364,12 +365,12 @@ namespace gs
                     // [TODO] this can be precomputed now...
                     List<GeneralPolygon2d> infill_regions = new List<GeneralPolygon2d>();
                     if (is_infill)
-						infill_regions = make_infill_regions(layer_i, solid_fill_regions, roof_cover, floor_cover, out solid_fill_regions);
+                        infill_regions = make_infill_regions(layer_i, solid_fill_regions, roof_cover, floor_cover, out solid_fill_regions);
                     bool has_infill = (infill_regions.Count > 0);
 
                     // fill solid regions
                     groupScheduler.BeginGroup();
-					// [RMS] always call this for now because we may have bridge regions
+                    // [RMS] always call this for now because we may have bridge regions
                     // [TODO] we can precompute the bridge region calc we are doing here that is quite expensive...
                     fill_solid_regions(solid_fill_regions, groupScheduler, layerdata, has_infill);
                     groupScheduler.EndGroup();
@@ -382,8 +383,9 @@ namespace gs
                     count_progress_step();
 
                     groupScheduler.BeginGroup();
-                    if (do_outer_last && outer_shell != null) {
-                        groupScheduler.AppendCurveSets( new List<FillCurveSet2d>() { outer_shell } );
+                    if (do_outer_last && outer_shell != null)
+                    {
+                        groupScheduler.AppendCurveSets(new List<FillCurveSet2d>() { outer_shell });
                     }
                     groupScheduler.EndGroup();
 
@@ -399,7 +401,7 @@ namespace gs
                 // discard the group scheduler
                 layerdata.Scheduler = groupScheduler.TargetScheduler;
 
-				// last chance to post-process paths for this layer before they are baked in
+                // last chance to post-process paths for this layer before they are baked in
                 if (Cancelled()) return;
                 if ( LayerPostProcessor != null )
                     LayerPostProcessor.Process(layerdata, pathAccum.Paths);
@@ -443,16 +445,19 @@ namespace gs
         /// <summary>
         /// assemble Settings for a given layer.
         /// </summary>
-        protected virtual SingleMaterialFFFSettings MakeLayerSettings(int layer_i)
+        protected virtual T MakeLayerSettings<T>(int layer_i) where T : ISingleMaterialFFFSettings, new()
         {
-            SingleMaterialFFFSettings layerSettings = Settings.CloneAs<SingleMaterialFFFSettings>();
+            var layerSettings = Settings.CloneAs<T>();
             PlanarSlice slice = Slices[layer_i];
             // override standard layer height with slice ZSpan
             layerSettings.LayerHeightMM = slice.LayerZSpan.Length;
             return layerSettings;
         }
 
-
+        protected virtual ISingleMaterialFFFSettings SettingsFactory(int layer_i)
+        {
+            return MakeLayerSettings<SingleMaterialFFFSettings>(layer_i);
+        }
 
         /// <summary>
         /// fill all infill regions
@@ -491,11 +496,11 @@ namespace gs
                 InsetFromInputPolygon = false,
                 PathSpacing = Settings.SparseLinearInfillStepX * Settings.SolidFillPathSpacingMM(),
                 ToolWidth = Settings.Machine.NozzleDiamMM,
-				AngleDeg = LayerFillAngleF(layer_data.layer_i)
+                AngleDeg = LayerFillAngleF(layer_data.layer_i)
             };
             infill_gen.Compute();
 
-			scheduler.AppendCurveSets(infill_gen.GetFillCurves());
+            scheduler.AppendCurveSets(infill_gen.GetFillCurves());
         }
 
 
@@ -517,36 +522,36 @@ namespace gs
         /// </summary>
 		protected virtual void fill_support_region(GeneralPolygon2d support_poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
         {
-			AxisAlignedBox2d bounds = support_poly.Bounds;
+            AxisAlignedBox2d bounds = support_poly.Bounds;
 
-			// settings may require a shell. However if support region
-			// is very small, we will also use nested shells because infill
-			// poly will likely be empty. In this case we nudge up the spacing
-			// so that they are more loosely bonded
+            // settings may require a shell. However if support region
+            // is very small, we will also use nested shells because infill
+            // poly will likely be empty. In this case we nudge up the spacing
+            // so that they are more loosely bonded
             // [TODO] we should only do this if we are directly below model. Otherwise this
             // branch is hit on any thin tube supports, that we could be printing empty
-			int nShells = (Settings.EnableSupportShell) ? 1 : 0;
+            int nShells = (Settings.EnableSupportShell) ? 1 : 0;
             double support_spacing = Settings.SupportSpacingStepX * Settings.Machine.NozzleDiamMM;
-			double shell_spacing = Settings.Machine.NozzleDiamMM;
+            double shell_spacing = Settings.Machine.NozzleDiamMM;
 			if (bounds.MaxDim < support_spacing) {
-				nShells = 3;
-				shell_spacing = Settings.Machine.NozzleDiamMM * 1.25f;
-			}
+                nShells = 3;
+                shell_spacing = Settings.Machine.NozzleDiamMM * 1.25f;
+            }
 
             List<GeneralPolygon2d> infill_polys = new List<GeneralPolygon2d>() { support_poly };
 
 			if (nShells > 0) {
                 ShellsFillPolygon shells_gen = new ShellsFillPolygon(support_poly);
-				shells_gen.PathSpacing = shell_spacing;
+                shells_gen.PathSpacing = shell_spacing;
                 shells_gen.ToolWidth = Settings.Machine.NozzleDiamMM;
-				shells_gen.Layers = nShells;
+                shells_gen.Layers = nShells;
                 shells_gen.FilterSelfOverlaps = false;
-				shells_gen.PreserveInputInsetTopology = true;
+                shells_gen.PreserveInputInsetTopology = true;
                 //shells_gen.FilterSelfOverlaps = true;
                 //shells_gen.PreserveOuterShells = false;
                 //shells_gen.SelfOverlapTolerance = Settings.SelfOverlapToleranceX * Settings.Machine.NozzleDiamMM;
-				shells_gen.DiscardTinyPolygonAreaMM2 = 0.1;
-				shells_gen.DiscardTinyPerimterLengthMM = 0.0;
+                shells_gen.DiscardTinyPolygonAreaMM2 = 0.1;
+                shells_gen.DiscardTinyPerimterLengthMM = 0.0;
                 shells_gen.Compute();
                 List<FillCurveSet2d> shell_fill_curves = shells_gen.GetFillCurves();
                 foreach (var fillpath in shell_fill_curves)
@@ -560,12 +565,12 @@ namespace gs
                     infill_polys = ClipperUtil.MiterOffset(inner_shells, offset);
                 }
 
-            } 
+            }
 
             foreach ( var poly in infill_polys ) {
                 SupportLinesFillPolygon infill_gen = new SupportLinesFillPolygon(poly) {
                     InsetFromInputPolygon = (Settings.EnableSupportShell == false),
-					PathSpacing = support_spacing,
+                    PathSpacing = support_spacing,
                     ToolWidth = Settings.Machine.NozzleDiamMM,
                     AngleDeg = 0,
                 };
@@ -589,36 +594,36 @@ namespace gs
             // if we have bridge regions on this layer, we subtract them from solid regions
             // and fill them using bridge strategy
             if (layer_data.layer_i > 0 && Settings.EnableBridging) {
-				// bridge regions for layer i were computed at layer i-1...
-				List<GeneralPolygon2d> bridge_regions = get_layer_bridge_area(layer_data.layer_i - 1);
+                // bridge regions for layer i were computed at layer i-1...
+                List<GeneralPolygon2d> bridge_regions = get_layer_bridge_area(layer_data.layer_i - 1);
 
 				if (bridge_regions.Count > 0) {
-					// bridge_regions are the physical bridge polygon.
-					// solid_regions are the regions we have not yet filled this layer.
-					// bridge works better if there is a 'landing pad' on either side, so we
-					// expand and then clip with the solid regions, to get actual bridge fill region.
+                    // bridge_regions are the physical bridge polygon.
+                    // solid_regions are the regions we have not yet filled this layer.
+                    // bridge works better if there is a 'landing pad' on either side, so we
+                    // expand and then clip with the solid regions, to get actual bridge fill region.
 
-					double path_width = Settings.Machine.NozzleDiamMM;
-					double shells_width = Settings.Shells * path_width;
+                    double path_width = Settings.Machine.NozzleDiamMM;
+                    double shells_width = Settings.Shells * path_width;
                     //bridge_regions = ClipperUtil.MiterOffset(bridge_regions, shells_width, filter_area);
                     bridge_regions = ClipperUtil.SeparateMiterOffsets(bridge_regions, shells_width, filter_area);
                     bridge_regions = ClipperUtil.Intersection(bridge_regions, solid_regions, filter_area);
                     bridge_regions = CurveUtils2.FilterDegenerate(bridge_regions, filter_area);     // [RMS] do we need to do this?
 
                     if (bridge_regions.Count > 0) {
-						// now have to subtract bridge region from solid region, in case there is leftover.
-						// We are not going to inset bridge region or solid fill,  
-						// so we need to add *two* half-width tolerances
-						//var offset_regions = ClipperUtil.MiterOffset(bridge_regions, Settings.Machine.NozzleDiamMM, filter_area);
+                        // now have to subtract bridge region from solid region, in case there is leftover.
+                        // We are not going to inset bridge region or solid fill,  
+                        // so we need to add *two* half-width tolerances
+                        //var offset_regions = ClipperUtil.MiterOffset(bridge_regions, Settings.Machine.NozzleDiamMM, filter_area);
                         var offset_regions = ClipperUtil.SeparateMiterOffsets(bridge_regions, Settings.Machine.NozzleDiamMM, filter_area);
                         solid_regions = ClipperUtil.Difference(solid_regions, offset_regions, filter_area);
                         solid_regions = CurveUtils2.FilterDegenerate(solid_regions, filter_area);     // [RMS] do we need to do this?
 
                         foreach (var bridge_poly in bridge_regions)
-							fill_bridge_region(bridge_poly, scheduler, layer_data);
-					}
-				}
-			}
+                            fill_bridge_region(bridge_poly, scheduler, layer_data);
+                    }
+                }
+            }
 
             foreach (GeneralPolygon2d solid_poly in solid_regions)
                 fill_solid_region(layer_data, solid_poly, scheduler, bIsInfillAdjacent);
@@ -633,8 +638,8 @@ namespace gs
         /// to sparse infill area - when the extruder zigs, most of the time there is nothing
         /// for the filament to attach to, so it pulls back. ugly!)
         /// </summary>
-        protected virtual void fill_solid_region(PrintLayerData layer_data, 
-		                                         GeneralPolygon2d solid_poly, 
+        protected virtual void fill_solid_region(PrintLayerData layer_data,
+                                                 GeneralPolygon2d solid_poly,
                                                  IFillPathScheduler2d scheduler,
                                                  bool bIsInfillAdjacent = false )
         {
@@ -680,42 +685,42 @@ namespace gs
 
                 solid_gen.Compute();
 
-				scheduler.AppendCurveSets(solid_gen.GetFillCurves());
+                scheduler.AppendCurveSets(solid_gen.GetFillCurves());
             }
         }
 
 
 
 
-		/// <summary>
-		/// Fill a bridge region. Goal is to use shortest paths possible.
-		/// So, instead of just using fixed angle, we fit bounding box and
-		/// use the shorter axis. 
-		/// </summary>
-		protected virtual void fill_bridge_region(GeneralPolygon2d poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
-		{
-			double spacing = Settings.BridgeFillPathSpacingMM();
+        /// <summary>
+        /// Fill a bridge region. Goal is to use shortest paths possible.
+        /// So, instead of just using fixed angle, we fit bounding box and
+        /// use the shorter axis. 
+        /// </summary>
+        protected virtual void fill_bridge_region(GeneralPolygon2d poly, IFillPathScheduler2d scheduler, PrintLayerData layer_data)
+        {
+            double spacing = Settings.BridgeFillPathSpacingMM();
 
-			// fit bbox to try to find fill angle that has shortest spans
-			Box2d box = poly.Outer.MinimalBoundingBox(0.00001);
-			Vector2d axis = (box.Extent.x > box.Extent.y) ? box.AxisY : box.AxisX;
-			double angle = Math.Atan2(axis.y, axis.x) * MathUtil.Rad2Deg;
+            // fit bbox to try to find fill angle that has shortest spans
+            Box2d box = poly.Outer.MinimalBoundingBox(0.00001);
+            Vector2d axis = (box.Extent.x > box.Extent.y) ? box.AxisY : box.AxisX;
+            double angle = Math.Atan2(axis.y, axis.x) * MathUtil.Rad2Deg;
 
-			// [RMS] should we do something like this?
-			//if (Settings.SolidFillBorderOverlapX > 0) {
-			//	double offset = Settings.Machine.NozzleDiamMM * Settings.SolidFillBorderOverlapX;
-			//	fillPolys = ClipperUtil.MiterOffset(fillPolys, offset);
-			//}
+            // [RMS] should we do something like this?
+            //if (Settings.SolidFillBorderOverlapX > 0) {
+            //	double offset = Settings.Machine.NozzleDiamMM * Settings.SolidFillBorderOverlapX;
+            //	fillPolys = ClipperUtil.MiterOffset(fillPolys, offset);
+            //}
 
 			BridgeLinesFillPolygon fill_gen = new BridgeLinesFillPolygon(poly) {
-				InsetFromInputPolygon = false,
-				PathSpacing = spacing,
-				ToolWidth = Settings.Machine.NozzleDiamMM,
-				AngleDeg = angle,
-			};
-			fill_gen.Compute();
-			scheduler.AppendCurveSets(fill_gen.GetFillCurves());
-		}
+                InsetFromInputPolygon = false,
+                PathSpacing = spacing,
+                ToolWidth = Settings.Machine.NozzleDiamMM,
+                AngleDeg = angle,
+            };
+            fill_gen.Compute();
+            scheduler.AppendCurveSets(fill_gen.GetFillCurves());
+        }
 
 
 
@@ -727,12 +732,12 @@ namespace gs
         /// Determine the sparse infill and solid fill regions for a layer, given the input regions that
         /// need to be filled, and the roof/floor areas above/below this layer. 
         /// </summary>
-        protected virtual List<GeneralPolygon2d> make_infill_regions(int layer_i, 
-		                                                     List<GeneralPolygon2d> fillRegions, 
-                                                             List<GeneralPolygon2d> roof_cover, 
-                                                             List<GeneralPolygon2d> floor_cover, 
+        protected virtual List<GeneralPolygon2d> make_infill_regions(int layer_i,
+                                                             List<GeneralPolygon2d> fillRegions,
+                                                             List<GeneralPolygon2d> roof_cover,
+                                                             List<GeneralPolygon2d> floor_cover,
                                                              out List<GeneralPolygon2d> solid_regions)
-                                                            
+
         {
             double min_area = Settings.Machine.NozzleDiamMM * Settings.Machine.NozzleDiamMM;
 
@@ -838,15 +843,15 @@ namespace gs
         /// </summary>
 		protected virtual void add_open_paths(PrintLayerData layerdata, IFillPathScheduler2d scheduler)
         {
-			PlanarSlice slice = layerdata.Slice;
+            PlanarSlice slice = layerdata.Slice;
             if (slice.Paths.Count == 0)
                 return;
 
             FillCurveSet2d paths = new FillCurveSet2d();
             for ( int pi = 0; pi < slice.Paths.Count; ++pi ) {
 				FillPolyline2d pline = new FillPolyline2d(slice.Paths[pi]) {
-					TypeFlags = FillTypeFlags.OpenShellCurve
-				};
+                    TypeFlags = FillTypeFlags.OpenShellCurve
+                };
 
                 // leave space for end-blobs (input paths are extent we want to hit)
                 pline.Trim(Settings.Machine.NozzleDiamMM / 2);
@@ -885,7 +890,7 @@ namespace gs
             //    PlanarSlice slice = Slices[layeri];
             //    LayerShells[layeri] = compute_shells_for_slice(slice);
             //}
-			return LayerShells[layer_i];
+            return LayerShells[layer_i];
         }
 
         /// <summary>
@@ -940,7 +945,7 @@ namespace gs
             shells_gen.Layers = Settings.Shells;
             shells_gen.FilterSelfOverlaps = Settings.ClipSelfOverlaps;
             shells_gen.SelfOverlapTolerance = Settings.SelfOverlapToleranceX * Settings.Machine.NozzleDiamMM;
-			shells_gen.OuterShellLast = Settings.OuterShellLast;
+            shells_gen.OuterShellLast = Settings.OuterShellLast;
 
             shells_gen.Compute();
             return shells_gen;
@@ -1022,19 +1027,19 @@ namespace gs
             return LayerSupportAreas[layer_i];
         }
 
-		// The set of bridge areas for each layer. These are basically the support
-		// areas that we can bridge. So, they are one layer below the model area.
-		protected List<GeneralPolygon2d>[] LayerBridgeAreas;
+        // The set of bridge areas for each layer. These are basically the support
+        // areas that we can bridge. So, they are one layer below the model area.
+        protected List<GeneralPolygon2d>[] LayerBridgeAreas;
 
-		/// <summary>
-		/// return the set of bridgeable support-region polygons for a layer.
-		/// Note that the bridge regions for layer i are at layer i-1 (because
-		/// these are the support areas)
-		/// </summary>
-		protected virtual List<GeneralPolygon2d> get_layer_bridge_area(int layer_i)
-		{
-			return LayerBridgeAreas[layer_i];
-		}
+        /// <summary>
+        /// return the set of bridgeable support-region polygons for a layer.
+        /// Note that the bridge regions for layer i are at layer i-1 (because
+        /// these are the support areas)
+        /// </summary>
+        protected virtual List<GeneralPolygon2d> get_layer_bridge_area(int layer_i)
+        {
+            return LayerBridgeAreas[layer_i];
+        }
 
 
 
@@ -1044,7 +1049,7 @@ namespace gs
         /// </summary>
         protected virtual void precompute_support_areas()
         {
-			generate_bridge_areas();
+            generate_bridge_areas();
 
             if (Settings.GenerateSupport)
                 generate_support_areas();
@@ -1053,32 +1058,32 @@ namespace gs
         }
 
 
-		/// <summary>
+        /// <summary>
         /// Find the unsupported regions in each layer that can be bridged
         /// </summary>
-		protected virtual void generate_bridge_areas()
-		{
-			int nLayers = Slices.Count;
+        protected virtual void generate_bridge_areas()
+        {
+            int nLayers = Slices.Count;
 
-			LayerBridgeAreas = new List<GeneralPolygon2d>[nLayers];
-			if (nLayers <= 1)
-				return;
+            LayerBridgeAreas = new List<GeneralPolygon2d>[nLayers];
+            if (nLayers <= 1)
+                return;
 
-			// [RMS] does this make sense? maybe should be using 0 here?
-			double bridge_tol = Settings.Machine.NozzleDiamMM * 0.5;
+            // [RMS] does this make sense? maybe should be using 0 here?
+            double bridge_tol = Settings.Machine.NozzleDiamMM * 0.5;
             double expand_delta = bridge_tol * 0.1;     // see usage below
             bridge_tol += expand_delta;
-			double min_area = Settings.Machine.NozzleDiamMM;
-			min_area *= min_area;
+            double min_area = Settings.Machine.NozzleDiamMM;
+            min_area *= min_area;
 
-			gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
+            gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
                 if (Cancelled()) return;
                 PlanarSlice slice = Slices[layeri];
-				PlanarSlice next_slice = Slices[layeri + 1];
+                PlanarSlice next_slice = Slices[layeri + 1];
 
-				// To find bridgeable regions, we compute all floating regions in next layer. 
-				// Then we look for polys that are bridgeable, ie thing enough and fully anchored.
-				List<GeneralPolygon2d> bridgePolys = null;
+                // To find bridgeable regions, we compute all floating regions in next layer. 
+                // Then we look for polys that are bridgeable, ie thing enough and fully anchored.
+                List<GeneralPolygon2d> bridgePolys = null;
 				if (Settings.EnableBridging) {
                     // [RMS] bridge area is (next_solids - solids). However, for meshes with slight variations
                     // in identical stacked polygons (eg like created from mesh extrusions), there will be thousands
@@ -1089,16 +1094,16 @@ namespace gs
                     bridgePolys = ClipperUtil.Difference(next_slice.Solids, expandPolys, min_area);
                     bridgePolys = CurveUtils2.FilterDegenerate(bridgePolys, min_area);
                     bridgePolys = CurveUtils2.Filter(bridgePolys, (p) => {
-						return layeri > 0 && is_bridgeable(p, layeri, bridge_tol);
-					});
-				}
+                        return layeri > 0 && is_bridgeable(p, layeri, bridge_tol);
+                    });
+                }
 
-				LayerBridgeAreas[layeri] = (bridgePolys != null)
-					? bridgePolys : new List<GeneralPolygon2d>();
-			});
-			LayerBridgeAreas[nLayers - 1] = new List<GeneralPolygon2d>();
+                LayerBridgeAreas[layeri] = (bridgePolys != null)
+                    ? bridgePolys : new List<GeneralPolygon2d>();
+            });
+            LayerBridgeAreas[nLayers - 1] = new List<GeneralPolygon2d>();
 
-		}
+        }
 
 
 
@@ -1142,93 +1147,93 @@ namespace gs
             // to ensure overlap. Using a larger value here has the effect of
             // smoothing out the support polygons. However it can also end up
             // merging disjoint regions...
-			double fMergeDownDilate = Settings.Machine.NozzleDiamMM * Settings.SupportRegionJoinTolX;
+            double fMergeDownDilate = Settings.Machine.NozzleDiamMM * Settings.SupportRegionJoinTolX;
 
             // space we leave between support polygons and solids
             // [TODO] do we need to include SupportAreaOffsetX here?
             double fSupportGapInLayer = Settings.SupportSolidSpace;
 
-			// extra offset we add to support polygons, eg to nudge them
-			// in/out depending on shell layers, etc
-			double fSupportOffset = Settings.SupportAreaOffsetX * Settings.Machine.NozzleDiamMM;
+            // extra offset we add to support polygons, eg to nudge them
+            // in/out depending on shell layers, etc
+            double fSupportOffset = Settings.SupportAreaOffsetX * Settings.Machine.NozzleDiamMM;
 
-			// we will throw away holes in support regions smaller than these thresholds
+            // we will throw away holes in support regions smaller than these thresholds
 			double DiscardHoleSizeMM = 2*Settings.Machine.NozzleDiamMM;
-			double DiscardHoleArea = DiscardHoleSizeMM * DiscardHoleSizeMM;
+            double DiscardHoleArea = DiscardHoleSizeMM * DiscardHoleSizeMM;
 
             // throw away support polygons smaller than this
             double fMinDiameter = Settings.SupportMinDimension;
 
-			// if support poly is further than this from model, we consider
-			// it a min-z-tip and it gets special handling
-			double fSupportMinDist = Settings.Machine.NozzleDiamMM;
+            // if support poly is further than this from model, we consider
+            // it a min-z-tip and it gets special handling
+            double fSupportMinDist = Settings.Machine.NozzleDiamMM;
 
 
 
             int nLayers = Slices.Count;
-			LayerSupportAreas = new List<GeneralPolygon2d>[nLayers];
-			if (nLayers <= 1)
-				return;
+            LayerSupportAreas = new List<GeneralPolygon2d>[nLayers];
+            if (nLayers <= 1)
+                return;
 
 
             bool bEnableInterLayerSmoothing = true;
 
 
-			/*
+            /*
 			 * Step 1: compute absolute support polygon for each layer
 			 */
 
-			// For layer i, compute support region needed to support layer (i+1)
-			// This is the *absolute* support area - no inset for filament width or spacing from model
-			gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
+            // For layer i, compute support region needed to support layer (i+1)
+            // This is the *absolute* support area - no inset for filament width or spacing from model
+            gParallel.ForEach(Interval1i.Range(nLayers - 1), (layeri) => {
                 if (Cancelled()) return;
                 PlanarSlice slice = Slices[layeri];
-				PlanarSlice next_slice = Slices[layeri + 1];
+                PlanarSlice next_slice = Slices[layeri + 1];
 
-				// expand this layer and subtract from next layer. leftovers are
-				// what needs to be supported on next layer.
-				List<GeneralPolygon2d> expandPolys = ClipperUtil.MiterOffset(slice.Solids, fOverhangAngleDist);
-				List<GeneralPolygon2d> supportPolys = ClipperUtil.Difference(next_slice.Solids, expandPolys);
+                // expand this layer and subtract from next layer. leftovers are
+                // what needs to be supported on next layer.
+                List<GeneralPolygon2d> expandPolys = ClipperUtil.MiterOffset(slice.Solids, fOverhangAngleDist);
+                List<GeneralPolygon2d> supportPolys = ClipperUtil.Difference(next_slice.Solids, expandPolys);
 
-				// subtract regions we are going to bridge
-				List<GeneralPolygon2d> bridgePolys = get_layer_bridge_area(layeri);
+                // subtract regions we are going to bridge
+                List<GeneralPolygon2d> bridgePolys = get_layer_bridge_area(layeri);
 				if (bridgePolys.Count > 0) {
-					supportPolys = ClipperUtil.Difference(supportPolys, bridgePolys);
-				}
+                    supportPolys = ClipperUtil.Difference(supportPolys, bridgePolys);
+                }
 
-				// if we have an support inset/outset, apply it here.
-				// for insets the poly may disappear, in that case we
-				// keep the original poly.
-				// [TODO] handle partial-disappears
+                // if we have an support inset/outset, apply it here.
+                // for insets the poly may disappear, in that case we
+                // keep the original poly.
+                // [TODO] handle partial-disappears
 				if (fSupportOffset != 0) {
-					List<GeneralPolygon2d> offsetPolys = new List<GeneralPolygon2d>();
+                    List<GeneralPolygon2d> offsetPolys = new List<GeneralPolygon2d>();
 					foreach (var poly in supportPolys) {
-						List<GeneralPolygon2d> offset = ClipperUtil.MiterOffset(poly, fSupportOffset);
-						// if offset is empty, use original poly
+                        List<GeneralPolygon2d> offset = ClipperUtil.MiterOffset(poly, fSupportOffset);
+                        // if offset is empty, use original poly
 						if (offset.Count == 0) {
-							offsetPolys.Add(poly);
+                            offsetPolys.Add(poly);
 						} else {
-							offsetPolys.AddRange(offset);
-						}
-					}
-					supportPolys = offsetPolys;
-				}
+                            offsetPolys.AddRange(offset);
+                        }
+                    }
+                    supportPolys = offsetPolys;
+                }
 
-				// now we need to deal with tiny polys. If they are min-z-tips,
-				// we want to add larger support regions underneath them. 
-				// We determine this by measuring distance to this layer.
-				// NOTE: we **cannot** discard tiny polys here, because a bunch of
-				// tiny per-layer polygons may merge into larger support regions
-				// after dilate/contract, eg on angled thin strips. 
+                // now we need to deal with tiny polys. If they are min-z-tips,
+                // we want to add larger support regions underneath them. 
+                // We determine this by measuring distance to this layer.
+                // NOTE: we **cannot** discard tiny polys here, because a bunch of
+                // tiny per-layer polygons may merge into larger support regions
+                // after dilate/contract, eg on angled thin strips. 
                 if ( true ) {
                     List<GeneralPolygon2d> filteredPolys = new List<GeneralPolygon2d>();
                     foreach ( var poly in supportPolys ) {
-					    var bounds = poly.Bounds;
-					    // big enough to keep
+                        var bounds = poly.Bounds;
+                        // big enough to keep
 					    if (bounds.MaxDim > fMinDiameter) {
-						    filteredPolys.Add(poly);
-						    continue;
-					    }
+                            filteredPolys.Add(poly);
+                            continue;
+                        }
 
                         // Find nearest point. If it is far from print volume, then this is a Min-Z "tip" region.
                         // These will get larger polys if SupportMinZTips is enabled
@@ -1258,14 +1263,14 @@ namespace gs
 
                         // ok force support
                         filteredPolys.Add(make_support_point_poly(bounds.Center, fMinDiameter));
-				    }
+                    }
                     supportPolys.Clear();
                     supportPolys.AddRange(filteredPolys);
-                } 
+                }
 
-				// add any explicit support points in this layer as circles
-				foreach (Vector2d v in slice.InputSupportPoints)
-					supportPolys.Add(make_support_point_poly(v));
+                // add any explicit support points in this layer as circles
+                foreach (Vector2d v in slice.InputSupportPoints)
+                    supportPolys.Add(make_support_point_poly(v));
 
                 if (PathClipRegions != null)
                     supportPolys = ClipperUtil.Intersection(supportPolys, PathClipRegions);
@@ -1276,14 +1281,14 @@ namespace gs
             LayerSupportAreas[nLayers-1] = new List<GeneralPolygon2d>();
 
 
-			/*
+            /*
 			 * Step 2: sweep support polygons downwards
 			 */
 
-			// now merge support layers. Process is to track "current" support area,
-			// at layer below we union with that layers support, and then subtract
-			// that layers solids. 
-			List<GeneralPolygon2d> prevSupport = LayerSupportAreas[nLayers - 1];
+            // now merge support layers. Process is to track "current" support area,
+            // at layer below we union with that layers support, and then subtract
+            // that layers solids. 
+            List<GeneralPolygon2d> prevSupport = LayerSupportAreas[nLayers - 1];
             for (int i = nLayers - 2; i >= 0; --i) {
                 if (Cancelled()) return;
                 PlanarSlice slice = Slices[i];
@@ -1299,12 +1304,12 @@ namespace gs
                     if ( grow || shrink )
                         CurveUtils2.LaplacianSmoothConstrained(copy.Outer, 0.5, 5, fMergeDownDilate, shrink, grow);
 
-					// [RMS] here we are also smoothing interior holes. However (in theory) this 
-					// smoothing might expand the hole outside of the Outer polygon. So if we
-					// have holes we intersect with that poly, inset by a printwidth.
-					// [TODO] do we really need this? if hole expands, it will still be
-					// clipped against model.
-					List<GeneralPolygon2d> outer_clip = (solid.Holes.Count == 0) ? null : ClipperUtil.MiterOffset(copy, -fPrintWidth);
+                    // [RMS] here we are also smoothing interior holes. However (in theory) this 
+                    // smoothing might expand the hole outside of the Outer polygon. So if we
+                    // have holes we intersect with that poly, inset by a printwidth.
+                    // [TODO] do we really need this? if hole expands, it will still be
+                    // clipped against model.
+                    List<GeneralPolygon2d> outer_clip = (solid.Holes.Count == 0) ? null : ClipperUtil.MiterOffset(copy, -fPrintWidth);
                     foreach (Polygon2d hole in solid.Holes) {
                         if (hole.Bounds.MaxDim < DiscardHoleSizeMM || Math.Abs(hole.SignedArea) < DiscardHoleArea)
                             continue;
@@ -1312,21 +1317,21 @@ namespace gs
                         if (grow || shrink)
                             CurveUtils2.LaplacianSmoothConstrained(new_hole, 0.5, 5, fMergeDownDilate, shrink, grow);
 
-						List<GeneralPolygon2d> clipped_holes =
-							ClipperUtil.Intersection(new GeneralPolygon2d(new_hole), outer_clip);
-						clipped_holes = CurveUtils2.FilterDegenerate(clipped_holes, DiscardHoleArea);
+                        List<GeneralPolygon2d> clipped_holes =
+                            ClipperUtil.Intersection(new GeneralPolygon2d(new_hole), outer_clip);
+                        clipped_holes = CurveUtils2.FilterDegenerate(clipped_holes, DiscardHoleArea);
                         foreach (GeneralPolygon2d cliphole in clipped_holes) {
-							if (cliphole.Outer.IsClockwise == false)
-								cliphole.Outer.Reverse();
-							copy.AddHole(cliphole.Outer, false);   // ignore any new sub-holes that were created
+                            if (cliphole.Outer.IsClockwise == false)
+                                cliphole.Outer.Reverse();
+                            copy.AddHole(cliphole.Outer, false);   // ignore any new sub-holes that were created
                         }
                     }
 
                     support_above.Add(copy);
                 }
 
-				// union down
-				List<GeneralPolygon2d> combineSupport = null;
+                // union down
+                List<GeneralPolygon2d> combineSupport = null;
 
                 // [TODO] should discard small interior holes here if they don't intersect layer...
 
@@ -1334,20 +1339,20 @@ namespace gs
                 // [RMS] support polygons on successive layers they will not necessarily intersect, because
                 // they are offset inwards on each layer. But as we merge down, we want them to be combined.
                 // So, we do a dilate / boolean / contract. 
-				// *But*, doing this can cause undesirable effects on the support polygons in
-				// simpler cases, particularly "windy shells" type things. So, if the boolean-of-dilations
-				// has the same topology as the input (approximated by count!!), we will just stick
-				// with the original polygons
-				combineSupport = ClipperUtil.Union(support_above, LayerSupportAreas[i]);
+                // *But*, doing this can cause undesirable effects on the support polygons in
+                // simpler cases, particularly "windy shells" type things. So, if the boolean-of-dilations
+                // has the same topology as the input (approximated by count!!), we will just stick
+                // with the original polygons
+                combineSupport = ClipperUtil.Union(support_above, LayerSupportAreas[i]);
 				if (fMergeDownDilate > 0) {
-					List<GeneralPolygon2d> dilateA = ClipperUtil.MiterOffset(support_above, fMergeDownDilate);
-					List<GeneralPolygon2d> dilateB = ClipperUtil.MiterOffset(LayerSupportAreas[i], fMergeDownDilate);
-					List<GeneralPolygon2d> dilatedUnion = ClipperUtil.Union(dilateA, dilateB);
-					// [RMS] this is not very sophisticated...
+                    List<GeneralPolygon2d> dilateA = ClipperUtil.MiterOffset(support_above, fMergeDownDilate);
+                    List<GeneralPolygon2d> dilateB = ClipperUtil.MiterOffset(LayerSupportAreas[i], fMergeDownDilate);
+                    List<GeneralPolygon2d> dilatedUnion = ClipperUtil.Union(dilateA, dilateB);
+                    // [RMS] this is not very sophisticated...
 					if (dilatedUnion.Count != combineSupport.Count) {
-						combineSupport = ClipperUtil.MiterOffset(dilatedUnion, -fMergeDownDilate);
-					}
-                } 
+                        combineSupport = ClipperUtil.MiterOffset(dilatedUnion, -fMergeDownDilate);
+                    }
+                }
 
                 // support area we propagate down is combined area minus solid
                 prevSupport = ClipperUtil.Difference(combineSupport, slice.Solids);
@@ -1416,85 +1421,85 @@ namespace gs
         }
 
 
-		/*
+        /*
 		 * Bridging and Support utility functions
-		 */ 
+		 */
 
-		/// <summary>
-		/// generate support point polygon (eg circle)
-		/// </summary>
-		protected virtual GeneralPolygon2d make_support_point_poly(Vector2d v, double diameter = -1)
-		{
+        /// <summary>
+        /// generate support point polygon (eg circle)
+        /// </summary>
+        protected virtual GeneralPolygon2d make_support_point_poly(Vector2d v, double diameter = -1)
+        {
 			if ( diameter <= 0 )
-				diameter = Settings.SupportPointDiam;
-			Polygon2d circ = Polygon2d.MakeCircle(
-				diameter * 0.5, Settings.SupportPointSides);
-			circ.Translate(v);
-			return new GeneralPolygon2d(circ);			
-		}
+                diameter = Settings.SupportPointDiam;
+            Polygon2d circ = Polygon2d.MakeCircle(
+                diameter * 0.5, Settings.SupportPointSides);
+            circ.Translate(v);
+            return new GeneralPolygon2d(circ);
+        }
 
-		/// <summary>
-		/// Check if polygon can be bridged. Currently we allow this if all hold:
-		/// 1) contracting by max bridge width produces empty polygon
-		/// 2) all "turning" vertices of polygon are connected to previous layer
-		/// [TODO] not sure this actually guarantees that unsupported distances
-		/// *between* turns are within bridge threshold...
-		/// </summary>
-		protected virtual bool is_bridgeable(GeneralPolygon2d support_poly, int iLayer, double fTolDelta)
-		{
-			double max_bridge_dist = Settings.MaxBridgeWidthMM;
+        /// <summary>
+        /// Check if polygon can be bridged. Currently we allow this if all hold:
+        /// 1) contracting by max bridge width produces empty polygon
+        /// 2) all "turning" vertices of polygon are connected to previous layer
+        /// [TODO] not sure this actually guarantees that unsupported distances
+        /// *between* turns are within bridge threshold...
+        /// </summary>
+        protected virtual bool is_bridgeable(GeneralPolygon2d support_poly, int iLayer, double fTolDelta)
+        {
+            double max_bridge_dist = Settings.MaxBridgeWidthMM;
 
-			// if we inset by half bridge dist, and this doesn't completely wipe out 
-			// polygon, then it is too wide to bridge, somewhere
-			// [TODO] this is a reasonable way to decompose into bridgeable chunks...
-			double inset_delta = max_bridge_dist * 0.55;
-			List<GeneralPolygon2d> offset = ClipperUtil.MiterOffset(support_poly, -inset_delta);
-			if (offset != null && offset.Count > 0)
-				return false;
+            // if we inset by half bridge dist, and this doesn't completely wipe out 
+            // polygon, then it is too wide to bridge, somewhere
+            // [TODO] this is a reasonable way to decompose into bridgeable chunks...
+            double inset_delta = max_bridge_dist * 0.55;
+            List<GeneralPolygon2d> offset = ClipperUtil.MiterOffset(support_poly, -inset_delta);
+            if (offset != null && offset.Count > 0)
+                return false;
 
-			if (is_fully_connected(support_poly.Outer, iLayer, fTolDelta) == false)
-				return false;
+            if (is_fully_connected(support_poly.Outer, iLayer, fTolDelta) == false)
+                return false;
 			foreach (var h in support_poly.Holes) {
-				if (is_fully_connected(h, iLayer, fTolDelta) == false)
-					return false;
-			}
+                if (is_fully_connected(h, iLayer, fTolDelta) == false)
+                    return false;
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		/// <summary> 
-		/// check if all turn vertices of poly are connected ( see is_connected(vector2d) )
-		/// </summary>
-		protected virtual bool is_fully_connected(Polygon2d poly, int iLayer, double fTolDelta)
-		{
-			int NV = poly.VertexCount;
+        /// <summary> 
+        /// check if all turn vertices of poly are connected ( see is_connected(vector2d) )
+        /// </summary>
+        protected virtual bool is_fully_connected(Polygon2d poly, int iLayer, double fTolDelta)
+        {
+            int NV = poly.VertexCount;
 			for (int k = 0; k < NV; ++k) {
-				Vector2d v = poly[k];
+                Vector2d v = poly[k];
 				if ( k > 0 && poly.OpeningAngleDeg(k) > 179 )
-					continue;
-				if (is_connected(poly[k], iLayer, fTolDelta) == false)
-					return false;
-			}
-			return true;
-		}
+                    continue;
+                if (is_connected(poly[k], iLayer, fTolDelta) == false)
+                    return false;
+            }
+            return true;
+        }
 
-		/// <summary>
-		/// Check if position is "connected" to a solid in the slice
-		/// at layer i, where connected means distance is within tolerance
-		/// [TODO] I don't think this will return true if pos is inside one of the solids...
-		/// </summary>
-		protected virtual bool is_connected(Vector2d pos, int iLayer, double fTolDelta)
-		{
-			double maxdist = fTolDelta;
-			double maxdist_sqr = maxdist * maxdist;
+        /// <summary>
+        /// Check if position is "connected" to a solid in the slice
+        /// at layer i, where connected means distance is within tolerance
+        /// [TODO] I don't think this will return true if pos is inside one of the solids...
+        /// </summary>
+        protected virtual bool is_connected(Vector2d pos, int iLayer, double fTolDelta)
+        {
+            double maxdist = fTolDelta;
+            double maxdist_sqr = maxdist * maxdist;
 
-			PlanarSlice slice = Slices[iLayer];
-			double dist_sqr = slice.DistanceSquared(pos, maxdist_sqr, true, true);
-			if (dist_sqr < maxdist_sqr)
-				return true;
-			
-			return false;
-		}
+            PlanarSlice slice = Slices[iLayer];
+            double dist_sqr = slice.DistanceSquared(pos, maxdist_sqr, true, true);
+            if (dist_sqr < maxdist_sqr)
+                return true;
+
+            return false;
+        }
 
 
 
@@ -1503,10 +1508,10 @@ namespace gs
         /// </summary>
 		protected virtual IFillPathScheduler2d get_layer_scheduler(PrintLayerData layer_data)
         {
-			SequentialScheduler2d scheduler = new SequentialScheduler2d(layer_data.PathAccum, layer_data.Settings);
+            SequentialScheduler2d scheduler = new SequentialScheduler2d(layer_data.PathAccum, layer_data.Settings);
 
             // be careful on first layer
-			scheduler.SpeedHint = (layer_data.layer_i == CurStartLayer) ?
+            scheduler.SpeedHint = (layer_data.layer_i == CurStartLayer) ?
                 SchedulerSpeedHint.Careful : SchedulerSpeedHint.Rapid;
 
             return scheduler;

--- a/tests/CalculateExtrusion.cs
+++ b/tests/CalculateExtrusion.cs
@@ -16,7 +16,7 @@ namespace gs
 	public class CalculateExtrusion 
 	{
 		public ToolpathSet Paths;
-		public SingleMaterialFFFSettings Settings;
+		public ISingleMaterialFFFSettings Settings;
 
         public bool EnableRetraction = true;
 
@@ -34,7 +34,7 @@ namespace gs
 		public double ExtrusionLength = 0;
 
 
-		public CalculateExtrusion(ToolpathSet paths, SingleMaterialFFFSettings settings) 
+		public CalculateExtrusion(ToolpathSet paths, ISingleMaterialFFFSettings settings) 
 		{
 			Paths = paths;
 			Settings = settings;

--- a/toolpathing/FillPathScheduler2d.cs
+++ b/toolpathing/FillPathScheduler2d.cs
@@ -6,7 +6,7 @@ namespace gs
 {
     public enum SchedulerSpeedHint
     {
-        Careful, Default, Rapid, MaxSpeed
+        Careful, Default, Rapid, MaxSpeed, First
     }
 
 
@@ -147,7 +147,7 @@ namespace gs
         // 2) if this is an outer perimeter, scale by outer perimeter speed multiplier
         // 3) if we are being "careful" and this is support, also use that multiplier
         //       (bit of a hack, currently means on first layer we do support extra slow)
-        double select_speed(FillCurve2d pathCurve)
+        protected virtual double select_speed(FillCurve2d pathCurve)
         {
             bool bIsSupport = pathCurve.HasTypeFlag(FillTypeFlags.SupportMaterial);
             bool bIsOuterPerimeter = pathCurve.HasTypeFlag(FillTypeFlags.OuterPerimeter);

--- a/toolpathing/FillPathScheduler2d.cs
+++ b/toolpathing/FillPathScheduler2d.cs
@@ -22,7 +22,7 @@ namespace gs
     public class SequentialScheduler2d : IFillPathScheduler2d
 	{
 		public ToolpathSetBuilder Builder;
-		public SingleMaterialFFFSettings Settings;
+		public ISingleMaterialFFFSettings Settings;
 
         public bool ExtrudeOnShortTravels = false;
         public double ShortTravelDistance = 0;
@@ -31,7 +31,7 @@ namespace gs
         public Action<List<FillCurveSet2d>, SequentialScheduler2d> OnAppendCurveSetsF = null;
 
 
-        public SequentialScheduler2d(ToolpathSetBuilder builder, SingleMaterialFFFSettings settings)
+        public SequentialScheduler2d(ToolpathSetBuilder builder, ISingleMaterialFFFSettings settings)
 		{
 			Builder = builder;
 			Settings = settings;

--- a/utility/CalculatePrintTime.cs
+++ b/utility/CalculatePrintTime.cs
@@ -55,13 +55,13 @@ namespace gs
     public class CalculatePrintTime
     {
         public ToolpathSet Paths;
-        public SingleMaterialFFFSettings Settings;
+        public ISingleMaterialFFFSettings Settings;
 
         // output statistics
         public PrintTimeStatistics TimeStatistics { get; private set; }
 
 
-        public CalculatePrintTime(ToolpathSet paths, SingleMaterialFFFSettings settings)
+        public CalculatePrintTime(ToolpathSet paths, ISingleMaterialFFFSettings settings)
         {
             Paths = paths;
             Settings = settings;


### PR DESCRIPTION
Tried to minimize it, but a bunch of white space formatting snuck in; I assume the style guidelines should be 4 spaces instead of tabs? 

Unfortunately the extrusion reporting got tangled up in this settings refactor, but if desired I can recreate it on it's own branch from master. 

Since I wasn't originally planning on merging this back upstream, I made some changes around settings replacing `CloneAs<T>` with `CopyFrom`; I'm guessing this may be breaking for Cotangent. 